### PR TITLE
Docker-compose --allow-no-migration migrations:migrate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       PHP_EXTENSION_PDO_PGSQL: 1
       PHP_EXTENSION_MYSQLI: 0
       STARTUP_COMMAND_1: composer install
-      STARTUP_COMMAND_2: NETTE_DEBUG=1 php bin/console migrations:migrate --no-interaction
+      STARTUP_COMMAND_2: NETTE_DEBUG=1 php bin/console migrations:migrate --no-interaction --allow-no-migration
       STARTUP_COMMAND_3: NETTE_DEBUG=1 php bin/console doctrine:fixtures:load --no-interaction
   database:
     image: dockette/postgres:10


### PR DESCRIPTION
It fixes situation when there is no doctrine migrations container will exit with code 4