### PR TITLE
Fix ObjectRepository/ObjectManager namespace.

### DIFF
--- a/app/model/Database/EntityManager.php
+++ b/app/model/Database/EntityManager.php
@@ -3,7 +3,7 @@
 namespace App\Model\Database;
 
 use App\Model\Database\Repository\AbstractRepository;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Nettrine\ORM\EntityManagerDecorator;
 
 class EntityManager extends EntityManagerDecorator

--- a/db/Fixtures/UserFixture.php
+++ b/db/Fixtures/UserFixture.php
@@ -4,7 +4,7 @@ namespace Database\Fixtures;
 
 use App\Model\Database\Entity\User;
 use App\Model\Security\Passwords;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 class UserFixture extends AbstractFixture
 {


### PR DESCRIPTION
Doctrine\Common\Persistence\ObjectRepository was moved to Doctrine\Persistence\ObjectRepository
Doctrine\Common\Persistence\ObjectManager was moved to Doctrine\Persistence\ObjectManager